### PR TITLE
Update transformer to correctly get primary keys

### DIFF
--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -134,7 +134,7 @@ class Transformer
 
             // primary keys...
             if ($table->hasPrimaryKey()) {
-                $tableKeysColumnsNames = $table->getPrimaryKeyColumns();
+                $tableKeysColumnsNames = array_keys($table->getPrimaryKeyColumns());
             }
 
             // ... + foreign keys


### PR DESCRIPTION
I tried using your package but it didn't work. `$table->getPrimaryKeyColumns()` returns an array where the keys are the column names; therefore you need to do `array_keys($table->getPrimaryKeyColumns())` to correctly build the `$tableKeysColumnsNames` array.